### PR TITLE
Implement Docker repository monitor.

### DIFF
--- a/Docker/InedoExtension/InedoExtension.csproj
+++ b/Docker/InedoExtension/InedoExtension.csproj
@@ -32,33 +32,34 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Inedo.Agents.Client, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=9de986a2f8db80fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.SDK.1.0.5\lib\net452\Inedo.Agents.Client.dll</HintPath>
+      <HintPath>..\packages\Inedo.SDK.1.1.2\lib\net452\Inedo.Agents.Client.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Inedo.ExecutionEngine, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=68703f0e52007e75, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.SDK.1.0.5\lib\net452\Inedo.ExecutionEngine.dll</HintPath>
+      <HintPath>..\packages\Inedo.SDK.1.1.2\lib\net452\Inedo.ExecutionEngine.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Inedo.SDK, Version=1.0.5.0, Culture=neutral, PublicKeyToken=29fae5dec3001603, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.SDK.1.0.5\lib\net452\Inedo.SDK.dll</HintPath>
+    <Reference Include="Inedo.SDK, Version=1.1.2.0, Culture=neutral, PublicKeyToken=29fae5dec3001603, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.SDK.1.1.2\lib\net452\Inedo.SDK.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="InedoLib, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=112cfb71329714a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.SDK.1.0.5\lib\net452\InedoLib.dll</HintPath>
+      <HintPath>..\packages\Inedo.SDK.1.1.2\lib\net452\InedoLib.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.SDK.1.0.5\lib\net452\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.SDK.1.1.2\lib\net452\Newtonsoft.Json.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Operations\Compose\ComposeOperationBase.cs" />
@@ -68,6 +69,8 @@
     <Compile Include="Operations\Compose\DockerComposeDownOperation.cs" />
     <Compile Include="Operations\Compose\DockerComposeUpOperation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RepositoryMonitors\DockerRepositoryCommit.cs" />
+    <Compile Include="RepositoryMonitors\DockerRepositoryMonitor.cs" />
     <Compile Include="SuggestionProviders\SignalSuggestionProvider.cs" />
     <Compile Include="Utils.cs" />
   </ItemGroup>

--- a/Docker/InedoExtension/RepositoryMonitors/DockerRepositoryCommit.cs
+++ b/Docker/InedoExtension/RepositoryMonitors/DockerRepositoryCommit.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Inedo.ExecutionEngine;
+using Inedo.Extensibility.RepositoryMonitors;
+using Inedo.Serialization;
+
+namespace Inedo.Extensions.Docker.RepositoryMonitors
+{
+    [Serializable]
+    internal sealed class DockerRepositoryCommit : RepositoryCommit
+    {
+        [Persistent]
+        public string Digest { get; set; }
+
+        public override bool Equals(RepositoryCommit other)
+        {
+            if (!(other is DockerRepositoryCommit dockerDigest))
+                return false;
+
+            return string.Equals(this.Digest, dockerDigest.Digest, StringComparison.OrdinalIgnoreCase);
+        }
+        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(this.Digest ?? string.Empty);
+
+        public override string GetFriendlyDescription() => this.ToString();
+
+        public override string ToString()
+        {
+            var digest = this.Digest?.Split(':').LastOrDefault();
+
+            if (digest?.Length > 8)
+                return digest.Substring(0, 8);
+            else
+                return digest ?? string.Empty;
+        }
+
+        public override IReadOnlyDictionary<RuntimeVariableName, RuntimeValue> GetRuntimeVariables()
+        {
+            return new Dictionary<RuntimeVariableName, RuntimeValue>
+            {
+                [new RuntimeVariableName("ImageDigest", RuntimeValueType.Scalar)] = this.Digest
+            };
+        }
+    }
+}

--- a/Docker/InedoExtension/RepositoryMonitors/DockerRepositoryMonitor.cs
+++ b/Docker/InedoExtension/RepositoryMonitors/DockerRepositoryMonitor.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Inedo.Diagnostics;
+using Inedo.Documentation;
+using Inedo.Extensibility.RepositoryMonitors;
+using Inedo.Serialization;
+using Newtonsoft.Json;
+
+namespace Inedo.Extensions.Docker.RepositoryMonitors
+{
+    [DisplayName("Docker")]
+    [Description("Monitors a Docker repository for new versions of tagged images.")]
+    public sealed class DockerRepositoryMonitor : RepositoryMonitor
+    {
+        [Required]
+        [Persistent]
+        [DisplayName("Image name")]
+        public string ImageName { get; set; }
+
+        public async override Task<IReadOnlyDictionary<string, RepositoryCommit>> GetCurrentCommitsAsync(IRepositoryMonitorContext context)
+        {
+            string repositoryUrl;
+            int firstSlash = this.ImageName.IndexOf('/');
+            if (firstSlash == -1 || this.ImageName.IndexOfAny(new[] { ':', '.' }, 0, firstSlash) == -1)
+                repositoryUrl = "https://registry.hub.docker.com/v2/" + Uri.EscapeUriString(this.ImageName);
+            else
+                repositoryUrl = "https://" + this.ImageName.Substring(0, firstSlash) + "/v2/" + Uri.EscapeUriString(this.ImageName.Substring(firstSlash + 1));
+
+            using (var client = new HttpClient())
+            {
+                string[] tags;
+                using (var response = await client.GetAsync(repositoryUrl + "/tags/list", context.CancellationToken))
+                {
+                    response.EnsureSuccessStatusCode();
+                    var body = await response.Content.ReadAsStringAsync();
+                    tags = JsonConvert.DeserializeAnonymousType(body, new { tags = new string[0] }).tags;
+                }
+
+                var results = new Dictionary<string, RepositoryCommit>();
+
+                foreach (var tag in tags)
+                {
+                    using (var response = await client.GetAsync(repositoryUrl + "/manifests/" + Uri.EscapeUriString(tag), context.CancellationToken))
+                    {
+                        if (!response.IsSuccessStatusCode)
+                        {
+                            this.LogWarning($"Request for tag {tag} failed: {(int)response.StatusCode} {response.ReasonPhrase}");
+                            continue;
+                        }
+
+                        var digest = response.Headers.GetValues("Docker-Content-Digest").FirstOrDefault();
+                        if (digest == null)
+                        {
+                            this.LogWarning($"Missing Docker-Content-Digest for tag {tag}");
+                            continue;
+                        }
+
+                        results[tag] = new DockerRepositoryCommit { Digest = digest };
+                    }
+                }
+
+                return results;
+            }
+        }
+
+        public override RichDescription GetDescription()
+        {
+            return new RichDescription("Docker image ", new Hilite(this.ImageName));
+        }
+    }
+}

--- a/Docker/InedoExtension/packages.config
+++ b/Docker/InedoExtension/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Inedo.SDK" version="1.0.5" targetFramework="net452" />
+  <package id="Inedo.SDK" version="1.1.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Does not currently handle authentication (not even anonymous auth), which means images on the official hub don't work.

Also, if repository monitors could access the regex that filters relevant branches, we could be a lot more efficient here.